### PR TITLE
Fix admin address and add user options

### DIFF
--- a/luasrc/model/cbi/syncthing.lua
+++ b/luasrc/model/cbi/syncthing.lua
@@ -14,8 +14,8 @@ o.rmempty = false
 
 gui_address = s:option(Value, "gui_address", translate("GUI access address"))
 gui_address.description = translate("Use 0.0.0.0 to monitor all access.")
-gui_address.default = "http://127.0.0.1:8384"
-gui_address.placeholder = "http://127.0.0.1:8384"
+gui_address.default = "http://0.0.0.0:8384"
+gui_address.placeholder = "http://0.0.0.0:8384"
 gui_address.rmempty = false
 
 home = s:option(Value, "home", translate("Configuration file directory"))
@@ -24,11 +24,12 @@ home.default = "/etc/syncthing"
 home.placeholder = "/etc/syncthing"
 home.rmempty = false
 
-user = s:option(Value, "user", translate("User"))
+user = s:option(ListValue, "user", translate("User"))
 user.description = translate("The default is syncthing, but it may cause permission denied. Syncthing officially does not recommend running as root.")
-user.default = "syncthing"
-user.placeholder = "syncthing"
-user.rmempty = false
+user:value("", translate("syncthing"))
+for u in luci.util.execi("cat /etc/passwd | cut -d ':' -f1") do
+	user:value(u)
+end
 
 macprocs = s:option(Value, "macprocs", translate("Thread limit"))
 macprocs.description = translate("0 to match the number of CPUs (default), >0 to explicitly specify concurrency.")


### PR DESCRIPTION
127.0.0.1 in the official configuration file must be changed to 0.0.0.0 to open the management page in the browser. See the official introduction of Syncthing...